### PR TITLE
第3回 APIサーバー echo課題内容

### DIFF
--- a/http_server/echo/Makefile
+++ b/http_server/echo/Makefile
@@ -15,5 +15,8 @@ square:
 square_bad_request:
 	curl -i localhost:8080/square -H "num:a"
 
+random_name:
+	curl localhost:8080/random_name
+
 incr:
 	curl -X POST localhost:8080/incr -H 'Content-Type: application/json' -d '{"num":3}'

--- a/http_server/echo/go.mod
+++ b/http_server/echo/go.mod
@@ -2,4 +2,7 @@ module github.com/mf-sakura/golang_study/http_server/echo
 
 go 1.14
 
-require github.com/labstack/echo/v4 v4.1.15
+require (
+	github.com/jaswdr/faker v1.0.2
+	github.com/labstack/echo/v4 v4.1.15
+)

--- a/http_server/echo/go.sum
+++ b/http_server/echo/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jaswdr/faker v1.0.2 h1:3iRZztCC4oU67i67qGcyhIxeKgHQQH/iCifJOj3uOSI=
+github.com/jaswdr/faker v1.0.2/go.mod h1:9S4x1SRPC3m+iLgZTx2HZ0/R1/B0hwuL8uvOAiuJNtg=
 github.com/labstack/echo/v4 v4.1.15 h1:4aE6KfJC+wCnMjODwcpeEGWGsRfszxZMwB3QVTECj2I=
 github.com/labstack/echo/v4 v4.1.15/go.mod h1:GWO5IBVzI371K8XJe50CSvHjQCafK6cw8R/moLhEU6o=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -49,6 +49,8 @@ func squareHandler(c echo.Context) error {
 	if err != nil {
 		// 他のエラーの可能性もあるがサンプルとして纏める
 		return echo.NewHTTPError(http.StatusBadRequest, "num is not integer")
+	} else if num >= 100 {
+		return echo.NewHTTPError(http.StatusBadRequest, "num is larger or equal than 100")
 	}
 	// fmt.Sprintfでフォーマットに沿った文字列を生成できる。
 	return c.String(http.StatusOK, fmt.Sprintf("Square of %d is equal to %d", num, num*num))

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -71,11 +71,15 @@ func incrementHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")
 	}
 	counter += incrRequest.Num
-	return c.String(http.StatusOK, fmt.Sprintf("Value of Counter is %d \n", counter))
+	return c.JSON(http.StatusOK, counterResponse{Counter: counter})
 }
 
 type incrRequest struct {
 	// jsonタグをつける事でjsonのunmarshalが出来る
 	// jsonパッケージに渡すので、Publicである必要がある
 	Num int `json:"num"`
+}
+
+type counterResponse struct {
+	Counter int `json:"counter"`
 }

--- a/http_server/echo/main.go
+++ b/http_server/echo/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
+	"github.com/jaswdr/faker"
 )
 
 var (
@@ -22,6 +23,8 @@ func main() {
 	e.GET("/401", unAuthorizedHandler)
 	// GET Headerの読み込み
 	e.GET("/square", squareHandler)
+	// GET ランダムな名前をパッケージで生成して応答
+	e.GET("/random_name", randamNameHandler)
 	// POST Bodyの読み込み
 	e.POST("/incr", incrementHandler)
 
@@ -54,6 +57,10 @@ func squareHandler(c echo.Context) error {
 	}
 	// fmt.Sprintfでフォーマットに沿った文字列を生成できる。
 	return c.String(http.StatusOK, fmt.Sprintf("Square of %d is equal to %d", num, num*num))
+}
+
+func randamNameHandler(c echo.Context) error {
+	return c.String(http.StatusOK, faker.New().Person().Name())
 }
 
 // Bodyから数字を取得してその数字だけCounterをIncrementするハンドラー


### PR DESCRIPTION
# esa
https://mf.esa.io/posts/127136#%E7%AC%AC3%E5%9B%9E%20API%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC

# 対象課題
https://github.com/inodev/golang_study/blob/master/http_server/echo/README.md

# 実施内容
1. `squareHandler`でnumが100以上の場合はバリデーションエラーとして、400エラーを返してください。
    - → https://github.com/inodev/golang_study/commit/c3144646e8a4d70a115bba3201a413e1c8b6a5d8
2. `incrementHandler`にPOST以外のリクエストを行った場合、405エラーが返る事を確認してください。  追加実装しなくてもechoの機能でリクエストが弾かれます。
    - → 確認済
3. 自分で1つAPIを追加してください。(何でも良いです)
    - → https://github.com/inodev/golang_study/commit/7358a83799b90fbb0ce137d3c6277fe4b001daef
4. `incrementHandler`で以下のJSONの形式でCounterの値を返してください。
```{"counter": 9}```
参考: https://echo.labstack.com/guide/response
    - → https://github.com/inodev/golang_study/commit/0df6239b6ce205c8d09f26ab4e2d7b181432d634
